### PR TITLE
fix: force host certificate instead of user certificat.

### DIFF
--- a/items/sign_host_keys.py
+++ b/items/sign_host_keys.py
@@ -99,7 +99,9 @@ class SignHostKeys(Item):
         cert = SSHCertificate.create(
             subject_pubkey=pubkey,
             ca_privkey=ca,
+
         )
+        cert.fields.cert_type = 2
         cert.fields.valid_after = datetime.now()
         cert.fields.valid_before = datetime.now() + timedelta(days=self.attributes.get('days_valid'))
         cert.sign()


### PR DESCRIPTION
Type 1 (default) is for user certificates. OpenSSH is now throwing a warning when the certificate is user cert instead of host cert.