### PR TITLE
feat: prohibit-password option for PermitRootLogin

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ These metadata keys are used, but all optional
     'additional_interfaces': [],
     'only_allow_secure_ciphers': True,
     'permit_root_login': False,
+    'permit_root_login_prohibit_password': False,
     'password_auth': False,
     'use_pam': False,
     'gateway_ports': False,

--- a/files/sshd_config
+++ b/files/sshd_config
@@ -44,6 +44,8 @@ MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@op
 #LoginGraceTime 2m
 % if node.metadata.get('openssh').get('permit_root_login'):
 PermitRootLogin yes
+% elif node.metadata.get('openssh').get('permit_root_login_prohibit_password'):
+PermitRootLogin prohibit-password
 % else:
 PermitRootLogin no
 % endif

--- a/metadata.py
+++ b/metadata.py
@@ -6,6 +6,7 @@ defaults = {
         'additional_interfaces': [],
         'only_allow_secure_ciphers': True,
         'permit_root_login': False,
+        'permit_root_login_prohibit_password': False,
         'password_auth': False,
         'use_pam': False,
         'gateway_ports': False,


### PR DESCRIPTION
Add option `prohibit-password` for `PermitRootLogin`, default to False, to be backward compatible.