### PR TITLE
Check and renew certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ These metadata keys are used, but all optional
         ],
         'ca_path': 'certs/ssh_ca',
         'ca_password': '',
+        'days_valid': 365,
+        'renew_days': 90,
     },
 },
 ```

--- a/items.py
+++ b/items.py
@@ -32,6 +32,11 @@ if node.metadata.get('openssh').get('sign_host_keys').get('enabled'):
         sign_host_keys[f'/etc/ssh/ssh_host_{key_format}_key'] = {
             'ca_password': conf.get('ca_password'),
             'ca_path': conf.get('ca_path'),
+            'days_valid': conf.get('days_valid'),
+            'renew_days': conf.get('renew_days'),
+            'triggers': [
+                'svc_systemd:ssh:restart',
+            ]
         }
 
 files = {

--- a/items/sign_host_keys.py
+++ b/items/sign_host_keys.py
@@ -104,8 +104,8 @@ class SignHostKeys(Item):
             ca_privkey=self.load_ca_private_key(),
         )
         cert.fields.cert_type = 2
-        cert.fields.valid_after = datetime.now()
-        cert.fields.valid_before = datetime.now() + timedelta(days=self.attributes.get('days_valid'))
+        cert.fields.valid_after = datetime.utcnow()
+        cert.fields.valid_before = datetime.utcnow() + timedelta(days=self.attributes.get('days_valid'))
         cert.sign()
         cert.to_file(filename=cert_file_local)
 

--- a/metadata.py
+++ b/metadata.py
@@ -21,6 +21,8 @@ defaults = {
             ],
             'ca_path': 'certs/ssh_ca',
             'ca_password': '',
+            'days_valid': 365,
+            'renew_days': 90,
         },
     }
 }


### PR DESCRIPTION
In the current implementation we are unable to set how many days the certificate should be valid, however it's set to ~ 10 years.

This fix will make the period configurable, I also introduced a variable to control how many days before the certificate should be renewed.

Another thing is that we are verifying the CA now and the bundle will restart the SSH service when there is a change on the certificates.